### PR TITLE
Trivia update, channel locking, and more!

### DIFF
--- a/bot2_music.py
+++ b/bot2_music.py
@@ -104,8 +104,8 @@ class Bot(discord.Client):
       filepath = "data/music/{}.webm".format(video.title)
       if(video.viewcount < 2500 or video.likes / video.dislikes < 10):
         await self.send_message(message.channel, "Sorry, that video has too little views / poor rating to be trusted.")
-      elif(video.length > 300):
-        await self.send_message(message.channel, "Max length of a request is **5 minutes**, please!")
+      elif(video.length > 420):
+        await self.send_message(message.channel, "Max length of a request is **7 minutes**, please!")
       else:
         await self.send_message(message.channel, "Currently downloading the requested song...")
         try:
@@ -134,8 +134,7 @@ class Bot(discord.Client):
         await self.play_next_song.wait()
 
   async def on_ready(self):
-    print('Logged in as')
-    print(self.user.name)
+    print('Music bot activated as...')
     print(self.user.id)
     print('------')
 

--- a/modules/funstuff.py
+++ b/modules/funstuff.py
@@ -1,0 +1,35 @@
+# - - External Libraries - - #
+from discord.ext import commands # Command interface
+import discord # Overall discord library
+import json, asyncio # json / asyncio libraries
+import sys, os # Lower-level operations libraries
+import urllib.request # Downloading
+import random # Random (RNG)
+
+# - - My libraries - - #
+import checks # Ensures various predefined conditions are met
+from utils import imageloader # Image downloader
+from utils.BasicUtility import *
+
+
+class FunStuff:
+  def __init__(self, bot):
+    self.bot = bot
+
+  @commands.command(pass_context=True, hidden=True)
+  async def funnify(self, ctx, mode : int, word : str):
+    print('funnify mode {} word {}'.format(mode, word))
+    if mode == 1:
+      m = ""
+      for i in word:
+        m += " "*random.randrange(1,10) + i + '\n'
+      await self.bot.say(m)
+
+    if mode == 2:
+      m = ""
+      for i in word:
+        m += random.randrange(0,10)*i + '\n'
+      await self.bot.say(m)
+  
+def setup(bot):
+  bot.add_cog(FunStuff(bot))

--- a/modules/leagueapi.py
+++ b/modules/leagueapi.py
@@ -32,7 +32,7 @@ class LeagueAPI:
 
   @commands.command(pass_context=True)
   async def player(self, ctx, name : str, show_id=False):
-    """League of Legends player data"""
+    """League of Legends player data (do not include spaces in names)"""
     # TODO: Incomplete (use other API queries to improve this)
     try:
       data = player_data(name)

--- a/modules/trivia.py
+++ b/modules/trivia.py
@@ -1,369 +1,216 @@
-from discord.ext import commands		# Command interface
-import discord							# Overall discord library
-import datetime, re 					# Datetime and regular expression libraries
-import json, asyncio					# json / asyncio libraries
-import sys, os 							# Lower-level operations libraries
-import requests 						# API queries
-import urllib.request 					# Downloading
-import random							# Random (RNG)
-from time import sleep					# For delays
+from discord.ext import commands    # Command interface
+import discord              # Overall discord library
+import datetime, time # Date stuffs 
+import re           # regular expression libraries
+import json, asyncio          # json / asyncio libraries
+import sys, os              # Lower-level operations libraries
+import requests             # API queries
+import urllib.request           # Downloading
+import random             # Random (RNG)
+from time import sleep          # For delays
 from collections import defaultdict 
-import numpy as np 						# Advanced number/set arithmetic
+import numpy as np            # Advanced number/set arithmetic
 
-from utils.Champion import *			# Various champion data related operations
+from utils.Champion import *      # Various champion data related operations
 from utils.BotConstants import *
-from utils import imageloader 			# Image downloader
+from utils import imageloader       # Image downloader
 
 class Trivia:
-	def __init__(self, bot):
-		self.bot = bot
-		self.game_types = ['name_to_spell', 'spell_to_name', 'title_to_name', 'name_to_title', 'max_or_min_stat', 'blurb_to_name', 'guess_the_skin']
-		self.game_p = [0.16, 0.16, 0.16, 0.16, 0.05, 0.16, 0.15]
-		self.wrong_message = "*{}* (guessed {}) is **incorrect**. You have **{}** seconds for anyone else to try again."
+  def __init__(self, bot):
+    self.bot = bot
+    self.game_types = ['name_to_spell', 'spell_to_name', 'title_to_name', 'name_to_title', 'max_or_min_stat', 'blurb_to_name', 'guess_the_skin']
+    self.game_p = [0.16, 0.16, 0.16, 0.16, 0.05, 0.16, 0.15]
+    self.wrong_message = "*{}* (guessed {}) is **incorrect**. You have **{}** seconds for anyone else to try again."
 
-	@commands.command(pass_context=True)
-	async def trivia(self, ctx, amt : int):
-		"""Play some trivia! (use with a number)"""
-		if botv.ingame():
-			await self.bot.say("Sorry, a game is currently in channel `{}` on **{}** server (by <@{}>)".format(*botv.get_gamedata()))
-			return
+  @commands.command(pass_context=True)
+  async def trivia(self, ctx, amt : int, fix = None):
+    """Play some trivia! (use with a number)"""
+    if botv.ingame():
+      await self.bot.say("Sorry, a game is currently in channel `{}` on **{}** server (by <@{}>)".format(*botv.get_gamedata()))
+      return
 
-		winners = defaultdict(int)
-		await self.bot.say("**Game: League of Legends trivia!**\n(warning: may occasionally miss an answer, be sure to repeat it if you know it is correct)")
-		current_channel = ctx.message.channel.id
-		botv.toggle_ingame()
-		botv.set_gamedata(ctx.message.channel.name, ctx.message.server.name, ctx.message.author)
+    winners = defaultdict(int)
+    await self.bot.say("**Game: League of Legends trivia!**\n(warning: may occasionally miss an answer, be sure to repeat it if you know it is correct)")
+    current_channel = ctx.message.channel.id
+    botv.toggle_ingame()
+    botv.set_gamedata(ctx.message.channel.name, ctx.message.server.name, ctx.message.author)
 
-		def notother(m):
-			m.channel.id == current_channel
+    def notother(m):
+      m.channel.id == current_channel
 
-		for i in range(0, amt if amt>=1 else 10000):
-			await self.bot.say("Question **{}** {}".format(i+1, "of {}".format(amt) if amt>=1 else ""))
-			game_type = np.random.choice(self.game_types, p=self.game_p)
-			champ_names = [name for name in load_champion_stats()]
-			champ_name = random.choice(champ_names)
-			data = load_champion_data(champ_name)
+    async def ask(final_answer):
+      """ Condensed methodology for asking questions in any question mode """
+      await self.bot.say('You have twenty seconds to submit an answer...\n\n**Note:** If you know it and want to save it for the end, be wary that it may not recognize some answers if multiple are simultaneous!')
 
-			"""For name_to_spell and spell_to_name games"""
-			ability_number = random.choice([0,1,2,3,'Passive']) 	# Q, W, E, R, Passive
-			ability_name = str(data['spells'][ability_number]['name']) if ability_number != 'Passive' else str(data['passive']['name'])
+      answers = {}
+      timeout = time.time() + (trivia_timeout - 10)
+      while time.time() < timeout:
+        ans = await self.bot.wait_for_message(timeout=1.0)
+        if ans and ans.channel.id == current_channel and ans.author.id != botv.id:
+          answers[ans.author.name] = ans.content
 
-			"""For name_to_title and title_to_name games"""
-			title = data['title']
+      await self.bot.say('Currently received an answer from: {}\n\nYou have ten more seconds to respond.'.format(', '.join(answers)))
 
-			print("debug: {}, {} {} {} {}".format(champ_name, title, ability_number, ability_name, [x.strip(' ') for x in re.split(',|/',ability_name.lower())]))
-			number_to_letter = {0: 'Q', 1: 'W', 2: 'E', 3: 'R', 'Passive': 'Passive'}
-			remaining = 60.0
+      timeout = time.time() + 10
+      while time.time() < timeout:
+        ans = await self.bot.wait_for_message(timeout=1.0)
+        if ans and ans.author.id != botv.id:
+          answers[ans.author.name] = ans.content
 
-			if(game_type == 'name_to_spell'):
-				possible = [x.strip(' ') for x in re.split(',|/',ability_name.lower())]
+      final_message = "**Here are the results**:\n"
+      for name,resp in answers.items():
+        final_message += "{} guessed `{}` ... ".format(name, resp)
+        if is_correct(resp):
+          winners[name] += 1
+          final_message += "**CORRECT!**\n"
+        else:
+          final_message += "*Incorrect*\n"
 
-				await self.bot.say("What is the name of **{}'s {}**?".format(champ_name, number_to_letter[ability_number]))
+      final_message += '\nThe answer was: **{}**\n'.format(final_answer)
+      await self.bot.say(final_message + '\n')
 
-				# Standard operations for start of trivia game #
-				answer = await self.bot.wait_for_message(timeout=remaining)
-				if(answer == None):
-					await self.bot.say("Times up, the answer was **{}**!".format(ability_name))
-					continue
-				while(answer.channel.id != current_channel or answer.author.id == botv.id):
-					answer = await self.bot.wait_for_message(timeout=remaining)
+    for i in range(0, amt if amt>=1 else 10000):
+      await self.bot.say("Question **{}** {}".format(i+1, "of {}".format(amt) if amt>=1 else ""))
+      game_type = np.random.choice(self.game_types, p=self.game_p)
+      if fix and fix in self.game_types:
+        game_type = fix
+      champ_names = [name for name in load_champion_stats()]
+      champ_name = random.choice(champ_names)
+      data = load_champion_data(champ_name)
+      trivia_timeout = 20
 
-				if(answer.content == '!quit'):
-					await self.bot.say("Trivia game ended manually by {}".format(ctx.message.author))
-					botv.toggle_ingame()
-					return
-				# End of standard operations for start of trivia game #
-				
-				while(answer != None and answer.content.lower() not in possible):
-					remaining -= 5.0
-					hint = "Here's a hint: **{}**".format(ability_name[0:int((60-remaining)/10)])
+      """For name_to_spell and spell_to_name games"""
+      ability_number = random.choice([0,1,2,3,'Passive'])   # Q, W, E, R, Passive
+      ability_name = str(data['spells'][ability_number]['name']) if ability_number != 'Passive' else str(data['passive']['name'])
 
-					if(remaining % 10 == 0):
-						await self.bot.say(hint)
-					await self.bot.say(self.wrong_message.format(answer.author, answer.content, remaining))
-					
-					answer = await self.bot.wait_for_message(timeout=remaining)
-					while(answer and answer.channel.id != current_channel):
-						answer = await self.bot.wait_for_message(timeout=remaining+1)
-				if(answer):
-					await self.bot.say("**{}** was correct! The answer was **{}**.\n\n".format(answer.author, ability_name))
-					winners[answer.author.name]+=1
-				else:
-					await self.bot.say("Times up, the answer was **{}**!".format(ability_name))
+      """For name_to_title and title_to_name games"""
+      title = data['title']
 
-			elif(game_type == 'spell_to_name'):
-				await self.bot.say("Whose ability is **{}**? (format example: Annie W)".format(ability_name))
-				
-				# Standard operations for start of trivia game #
-				answer = await self.bot.wait_for_message(timeout=remaining)
-				if(answer == None):
-					await self.bot.say("Times up, the answer was **{}'s {}**!".format(champ_name, number_to_letter[ability_number]))
-					continue
-				while(answer.channel.id != current_channel or answer.author.id == botv.id):
-					answer = await self.bot.wait_for_message(timeout=remaining)
+      print("debug: {}, {} {} {} {}".format(champ_name, title, ability_number, ability_name, [x.strip(' ') for x in re.split(',|/',ability_name.lower())]))
+      number_to_letter = {0: 'Q', 1: 'W', 2: 'E', 3: 'R', 'Passive': 'Passive'}
+      remaining = 60.0
 
-				if(answer.content == '!quit'):
-					await self.bot.say("Trivia game ended manually by {}".format(ctx.message.author))
-					botv.toggle_ingame()
-					return
-				# End of standard operations for start of trivia game #
-				
-				def is_correct(inp):
-					try:
-						name = str(re.sub('\'|\s','',''.join(inp.split()[:-1])))
-						abil = inp.split()[-1]
-						if(name.lower() != champ_name.lower() or abil.lower() != number_to_letter[ability_number].lower()):
-							return False
-					except Exception as e:
-						return False
-					return True
+      if(game_type == 'name_to_spell'):
+        """ NAME TO SPELL PORTION """
+        possible = [x.strip(' ') for x in re.split(',|/',ability_name.lower())]
 
-				while(answer != None and not is_correct(answer.content)):
-					remaining -= 5.0
-					hint = "Here's a hint: **{}**".format(champ_name[0:int((60-remaining)/20)])
+        def is_correct(inp):
+          inp.lower().strip() in possible
 
-					if(remaining % 20 == 0):
-						await self.bot.say(hint)
-					await self.bot.say(self.wrong_message.format(answer.author, answer.content, remaining))
-					answer = await self.bot.wait_for_message(timeout=remaining)
-					while(answer and answer.channel.id != current_channel):
-						answer = await self.bot.wait_for_message(timeout=remaining)
-				if(answer):
-					await self.bot.say("**{}** was correct! The answer was **{}'s {}**.\n\n".format(answer.author, champ_name, number_to_letter[ability_number]))
-					winners[answer.author.name]+=1
-				else:
-					await self.bot.say("Times up, the answer was **{}'s {}**!".format(champ_name, number_to_letter[ability_number]))
+        await self.bot.say("What is the name of **{}'s {}**?".format(champ_name, number_to_letter[ability_number]))     
+        await ask(ability_name)
 
-			elif(game_type == 'title_to_name'):
-				await self.bot.say("Who is this? {}, {}".format("\_\_\_\_\_\_\_\_", title))
-				
-				# Standard operations for start of trivia game #
-				answer = await self.bot.wait_for_message(timeout=remaining)
-				if(answer == None):
-					await self.bot.say("Times up, the answer was **{}**!".format(champ_name))
-					continue
-				while(answer.channel.id != current_channel or answer.author.id == botv.id):
-					answer = await self.bot.wait_for_message(timeout=remaining)
+      elif(game_type == 'spell_to_name'):
+        """ SPELL TO NAME PORTION """
+        def is_correct(inp):
+          try:
+            name = str(re.sub('\'|\s','',''.join(inp.split()[:-1])))
+            abil = inp.split()[-1]
+            if(name.lower() != champ_name.lower() or abil.lower() != number_to_letter[ability_number].lower()):
+              return False
+          except Exception as e:
+            return False
+          return True
 
-				if(answer.content == '!quit'):
-					await self.bot.say("Trivia game ended manually by {}".format(ctx.message.author))
-					botv.toggle_ingame()
-					return
-				# End of standard operations for start of trivia game #
-				
-				def is_correct(inp):
-					try:
-						name = str(re.sub('\'|\s','',inp)).lower()
-						if(name != champ_name.lower()):
-							return False
-					except Exception as e:
-						return False
-					return True
+        await self.bot.say("Whose ability is **{}**? (format example: Annie W)".format(ability_name))
+        await ask(champ_name + " " + abil)
 
-				while(answer != None and not is_correct(answer.content)):
-					remaining -= 5.0
-					hint = "Here's a hint: **{}**".format(champ_name[0:int((60-remaining)/20)])
+      elif(game_type == 'title_to_name'):
+        """ TITLE TO NAME PORTION """
+        def is_correct(inp):
+          try:
+            name = str(re.sub('\'|\s','',inp)).lower()
+            if(name != champ_name.lower()):
+              return False
+          except Exception as e:
+            return False
+          return True
 
-					if(remaining % 20 == 0):
-						await self.bot.say(hint)
-					await self.bot.say(self.wrong_message.format(answer.author, answer.content, remaining))
-					answer = await self.bot.wait_for_message(timeout=remaining)
-					while(answer and (answer.channel.id != current_channel or answer.author.id == botv.id)):
-						answer = await self.bot.wait_for_message(timeout=remaining)
-				if(answer):
-					await self.bot.say("**{}** was correct! The answer was **{}**.\n\n".format(answer.author, champ_name))
-					winners[answer.author.name]+=1
-				else:
-					await self.bot.say("Times up, the answer was **{}**!".format(champ_name))
+        await self.bot.say("Who is this? {}, {}".format("\_\_\_\_\_\_\_\_", title))
+        await ask(champ_name)
 
-			elif(game_type == 'name_to_title'):
-				await self.bot.say("What is the title for **{}**?".format(champ_name))
-				
-				# Standard operations for start of trivia game #
-				answer = await self.bot.wait_for_message(timeout=remaining)
-				if(answer == None):
-					await self.bot.say("Times up, the answer was **{}**!".format(title))
-					continue
-				while(answer.channel.id != current_channel or answer.author.id == botv.id):
-					answer = await self.bot.wait_for_message(timeout=remaining)
+      elif(game_type == 'name_to_title'):
+        """ NAME TO TITLE PORTION """
+        def is_correct(inp):
+          inp.lower().strip() == title.lower()
 
-				if(answer.content == '!quit'):
-					await self.bot.say("Trivia game ended manually by {}".format(ctx.message.author))
-					botv.toggle_ingame()
-					return
-				# End of standard operations for start of trivia game #
+        await self.bot.say("What is the title for **{}**?".format(champ_name))
+        await ask(title)
 
-				while(answer != None and answer.content.lower() != title.lower()):
-					remaining -= 5.0
-					hint = "Here's a hint: **{}**".format(title[0:int((60-remaining)/10)])
+      elif(game_type == 'max_or_min_stat'):
+        """ MIN OR MAX STAT PORTION """
+        stat = random.choice(['movespeed','armor','hp','mp','spellblock','attackdamage'])
+        readable_stat = {'movespeed': 'movement speed', 'armor': 'armor', 'hp': 'health', 'mp': 'mana', 'spellblock': 'magic resist', 'attackdamage': 'AD'}
+        which_one = random.choice(['highest','lowest'])
+        data = load_champion_stats()
 
-					if(remaining % 10 == 0):
-						await self.bot.say(hint)
-					await self.bot.say(self.wrong_message.format(answer.author, answer.content, remaining))
-					answer = await self.bot.wait_for_message(timeout=remaining)
-					while(answer and (answer.channel.id != current_channel or answer.author.id == botv.id)):
-						answer = await self.bot.wait_for_message(timeout=remaining)
-				if(answer):
-					await self.bot.say("**{}** was correct! The answer was **{}**.\n\n".format(answer.author, title))
-					winners[answer.author.name]+=1
-				else:
-					await self.bot.say("Times up, the answer was **{}**!".format(title))
+        if(which_one == 'highest'):
+          champ_name = max(data, key = lambda item: int(data[item]['stats'][stat]))
+        else:
+          champ_name = min(data, key = lambda item: int(data[item]['stats'][stat]))
+        value = data[champ_name]['stats'][stat]
+        potential_champs = [champ.lower() for champ in data if data[champ]['stats'][stat] == value]
 
-			elif(game_type == 'max_or_min_stat'):
-				stat = random.choice(['movespeed','armor','hp','mp','spellblock','attackdamage'])
-				readable_stat = {'movespeed': 'movement speed', 'armor': 'armor', 'hp': 'health', 'mp': 'mana', 'spellblock': 'magic resist', 'attackdamage': 'AD'}
-				which_one = random.choice(['highest','lowest'])
-				data = load_champion_stats()
+        def is_correct(inp):
+          try:
+            name = str(re.sub('\'|\s','',inp)).lower()
+            if(name not in potential_champs):
+              return False
+          except Exception as e:
+            return False
+          return True
 
-				if(which_one == 'highest'):
-					champ_name = max(data, key = lambda item: int(data[item]['stats'][stat]))
-				else:
-					champ_name = min(data, key = lambda item: int(data[item]['stats'][stat]))
-				value = data[champ_name]['stats'][stat]
-				potential_champs = [champ.lower() for champ in data if data[champ]['stats'][stat] == value]
+        print("debug 2: {} {} ({}) = {}".format(which_one, readable_stat[stat], stat, champ_name))
+        await self.bot.say("Which champion has the **{}** base (level 1) {} in the game?".format(which_one, readable_stat[stat]))
+        await ask(champ_name)
 
-				print("debug 2: {} {} ({}) = {}".format(which_one, readable_stat[stat], stat, champ_name))
+      elif(game_type == 'blurb_to_name'):
+        """ BLURB TO NAME PORTION """
+        reg = re.compile(re.escape(champ_name), re.IGNORECASE)
+        blurb = reg.sub('********', data['blurb'].replace('<br>','\n')).replace(data['name'], '*******')
+        
+        def is_correct(inp):
+          try:
+            name = str(re.sub('\'|\s','',inp)).lower()
+            if(name != champ_name.lower()):
+              return False
+          except Exception as e:
+            return False
+          return True
 
-				await self.bot.say("Which champion has the **{}** base (level 1) {} in the game?".format(which_one, readable_stat[stat]))
+        await self.bot.say("Who does this sound like?\n```\n{}\n```".format(blurb))
+        await ask(champ_name)
 
-				# Standard operations for start of trivia game #
-				answer = await self.bot.wait_for_message(timeout=remaining)
-				if(answer == None):
-					await self.bot.say("Times up, the answer was **{}** (w/ {} {})!".format(' / '.join(potential_champs), value, readable_stat[stat]))
-					continue
-				while(answer.channel.id != current_channel or answer.author.id == botv.id):
-					answer = await self.bot.wait_for_message(timeout=remaining)
+      elif(game_type == 'guess_the_skin'):
+        """ GUESS THE SKIN PORTION """
+        await self.bot.say("What is this skin?")
+        skins =  [(ch['name'], ch['num']) for ch in data['skins'] if ch['name'] != 'default']
+        skin = random.choice(skins)
+        try:
+          imageloader.load_splash_art(champ_name, skin[1], champ_names)
+        except Exception as e:
+          await bot.say('Something went wrong, sorry!')
+          continue
 
-				if(answer.content == '!quit'):
-					await self.bot.say("Trivia game ended manually by {}".format(ctx.message.author))
-					botv.toggle_ingame()
-					return
-				# End of standard operations for start of trivia game #
+        def is_correct(i):
+          print(i.lower() + " / " + skin[0].lower())
+          return i.lower().strip() == skin[0].lower()
 
-				def is_correct(inp):
-					try:
-						name = str(re.sub('\'|\s','',inp)).lower()
-						if(name not in potential_champs):
-							return False
-					except Exception as e:
-						return False
-					return True
+        print('debug2: {}'.format(skin))
+        await self.bot.send_file(ctx.message.channel, 'data/league/current_splash.jpg')
+        await ask(skin[0])
 
-				while(answer != None and not is_correct(answer.content)):
-					remaining -= 5.0
-					hint = "Here's a hint: **{}**".format(champ_name[0:int((60-remaining)/10)])
+      winners_message = "**Current winners:**\n"
+      for q in sorted(winners, key=winners.get, reverse=True):
+        winners_message += '{}: *{}* correct\n'.format(q, winners[q])
+      await self.bot.say(winners_message + '\n')
 
-					if(remaining % 10 == 0):
-						await self.bot.say(hint)
-					await self.bot.say(self.wrong_message.format(answer.author, answer.content, remaining))
-					answer = await self.bot.wait_for_message(timeout=remaining)
-					while(answer and (answer.channel.id != current_channel or answer.author.id == botv.id)):
-						answer = await self.bot.wait_for_message(timeout=remaining)
-				if(answer):
-					await self.bot.say("**{}** was correct! The answer was **{}** (w/ {} {}).\n\n".format(answer.author, ' / '.join(potential_champs), value, readable_stat[stat]))
-					winners[answer.author.name]+=1
-				else:
-					await self.bot.say("Times up, the answer was **{}** (w/ {} {})!".format(' / '.join(potential_champs), value, readable_stat[stat]))
-
-			elif(game_type == 'blurb_to_name'):
-				reg = re.compile(re.escape(champ_name), re.IGNORECASE)
-				blurb = reg.sub('********', data['blurb'].replace('<br>','\n')).replace(data['name'], '*******')
-				await self.bot.say("Who does this sound like?\n```\n{}\n```".format(blurb))
-				
-				# Standard operations for start of trivia game #
-				answer = await self.bot.wait_for_message(timeout=remaining)
-				if(answer == None):
-					await self.bot.say("Times up, the answer was **{}**!".format(champ_name))
-					continue
-				while(answer.channel.id != current_channel or answer.author.id == botv.id):
-					answer = await self.bot.wait_for_message(timeout=remaining)
-
-				if(answer.content == '!quit'):
-					await self.bot.say("Trivia game ended manually by {}".format(ctx.message.author))
-					botv.toggle_ingame()
-					return
-				# End of standard operations for start of trivia game #
-				
-				def is_correct(inp):
-					try:
-						name = str(re.sub('\'|\s','',inp)).lower()
-						if(name != champ_name.lower()):
-							return False
-					except Exception as e:
-						return False
-					return True
-
-				while(answer != None and not is_correct(answer.content)):
-					remaining -= 5.0
-					hint = "Here's a hint: **{}**".format(champ_name[0:int((60-remaining)/20)])
-
-					if(remaining % 20 == 0):
-						await self.bot.say(hint)
-					await self.bot.say(self.wrong_message.format(answer.author, answer.content, remaining))
-					answer = await self.bot.wait_for_message(timeout=remaining)
-					while(answer and (answer.channel.id != current_channel or answer.author.id == botv.id)):
-						answer = await self.bot.wait_for_message(timeout=remaining)
-				if(answer):
-					await self.bot.say("**{}** was correct! The answer was **{}**.\n\n".format(answer.author, champ_name))
-					winners[answer.author.name]+=1
-				else:
-					await self.bot.say("Times up, the answer was **{}**!".format(champ_name))
-
-			elif(game_type == 'guess_the_skin'):
-				await self.bot.say("What is this skin?")
-				skins =  [(ch['name'], ch['num']) for ch in data['skins'] if ch['name'] != 'default']
-				skin = random.choice(skins)
-				try:
-					imageloader.load_splash_art(champ_name, skin[1], champ_names)
-				except Exception as e:
-					await bot.say('Something went wrong, sorry!')
-					continue
-
-				print('debug2: {}'.format(skin))
-
-				await self.bot.send_file(ctx.message.channel, 'data/league/current_splash.jpg')
-				
-				# Standard operations for start of trivia game #
-				answer = await self.bot.wait_for_message(timeout=remaining)
-				if(answer == None):
-					await self.bot.say("Times up, the answer was **{}**!".format(skin[0]))
-					continue
-				while(answer.channel.id != current_channel or answer.author.id == botv.id):
-					answer = await self.bot.wait_for_message(timeout=remaining)
-
-				if(answer.content == '!quit'):
-					await self.bot.say("Trivia game ended manually by {}".format(ctx.message.author))
-					botv.toggle_ingame()
-					return
-				# End of standard operations for start of trivia game #
-
-				while(answer != None and answer.content.lower() != skin[0].lower()):
-					remaining -= 5.0
-					hint = "Here's a hint: **{}**".format(skin[0][0:int((60-remaining)/10)])
-
-					if(remaining % 10 == 0):
-						await self.bot.say(hint)
-					await self.bot.say(self.wrong_message.format(answer.author, answer.content, remaining))
-					answer = await self.bot.wait_for_message(timeout=remaining)
-					while(answer and (answer.channel.id != current_channel or answer.author.id == botv.id)):
-						answer = await self.bot.wait_for_message(timeout=remaining)
-				if(answer):
-					await self.bot.say("**{}** was correct! The answer was **{}**.\n\n".format(answer.author, skin[0]))
-					winners[answer.author.name]+=1
-				else:
-					await self.bot.say("Times up, the answer was **{}**!".format(skin[0]))
-
-			winners_message = "**Current winners:**\n"
-			for q in sorted(winners, key=winners.get, reverse=True):
-				winners_message += '{}: *{}* correct\n'.format(q, winners[q])
-			await self.bot.say(winners_message + '\n')
-
-			delay = 10 if amt >= 1 else 30
-			if(i<amt-1 or amt==0):
-				await self.bot.say("Next question in {} seconds...".format(delay))
-			
-			sleep(delay)
-		botv.toggle_ingame()
+      delay = 10 if amt >= 1 else 30
+      if(i<amt-1 or amt==0):
+        await self.bot.say("Next question in {} seconds...".format(delay))
+      
+      sleep(delay)
+    botv.toggle_ingame()
 
 def setup(bot):
-	bot.add_cog(Trivia(bot))
+  bot.add_cog(Trivia(bot))

--- a/utils/BasicUtility.py
+++ b/utils/BasicUtility.py
@@ -19,3 +19,6 @@ def admins():
 
 def custom_command_list():
   return [x[:-5] for x in os.listdir('./data/custom_commands')]
+
+def clean(i):
+  return i.lower().replace(' ','')

--- a/utils/BotConstants.py
+++ b/utils/BotConstants.py
@@ -1,20 +1,23 @@
 class BotConstants:
-	def __init__(self):
-		self.__ingame = False
-		self.__gamechannel = None
-		self.__gameserver = None
-		self.__gamestarter = None
-		self.id = '133745418797318144'
-	def toggle_ingame(self):
-		self.__ingame = not self.__ingame
-	def ingame(self):
-		return self.__ingame
-	def set_gamedata(self, channel, server, starter):
-		self.__gamechannel = channel
-		self.__gameserver = server
-		self.__gamestarter = starter
-	def get_gamedata(self):
-		return [self.__gamechannel, self.__gameserver, self.__gamestarter.id]
+  def __init__(self):
+    self.__ingame = False
+    self.__gamechannel = None
+    self.__gameserver = None
+    self.__gamestarter = None
+    self.id = '133745418797318144'
+    self.private_channel = None
+  def set_private_channel(self, channel):
+    self.private_channel = channel
+  def toggle_ingame(self):
+    self.__ingame = not self.__ingame
+  def ingame(self):
+    return self.__ingame
+  def set_gamedata(self, channel, server, starter):
+    self.__gamechannel = channel
+    self.__gameserver = server
+    self.__gamestarter = starter
+  def get_gamedata(self):
+    return [self.__gamechannel, self.__gameserver, self.__gamestarter.id]
 
 
 botv = BotConstants()


### PR DESCRIPTION
Note: Some of these changes will require the bot to have certain permissions. This time around, they all refer to the `move_members` permission.
## Added
- **Channel locking!** You can now lock your channel with `;lock`. This will prevent ALL access (including being moved in by others) until unlocked or the bot is shut off. Use `;unlock` to unlock the channel.
- `channelkick` has been added. This will remove all users from the existing channel
- **Announcements!** You can now auto-generate an announcement to anyone by specifying the role's name (no spaces if there are spaces) and the message to announce.
- **Surveys!** Like with announcements, specify a role (no spaces) and a question to ask. It will PM every member of the role and look for responses, then PM you a collective list of every response at the end of it.
- Trivia will now use a collective pooling method for answers. There is no longer a "first right answer wins", instead it will pool all answers over 20 seconds (subject to change) and grant points to all who submit a correct answer in that time.
## Removed
- Prints username in console upon startup (removed to prevent errors with bots that have special characters in names)
- "One winner" methodology for trivia winning. See `Added` for new system.
## Fixes
- None this time around
## Optimization
- The Trivia code has been heavily optimized. From around ~400lines to about 220 now. Still lots to be done here.
